### PR TITLE
Skip expensive copy on COO conversion for scalability [VS-506]

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ NOTE: if multiple data sets are being loaded into the same dataset, offsets for 
 
 ### Ingest into BigQuery
 
-Example using a specific projct (broad-dsp-spec-ops) and dataset (kc_cas_test_v1)
+Example using a specific project (broad-dsp-spec-ops) and dataset (kc_cas_test_v1)
 
 ```
 bq load -project_id broad-dsp-spec-ops -F tab --skip_leading_rows 1 kc_cas_test_v1.cas_cell_info cas_cell_info.tsv.gz

--- a/src/anndata_to_bq.py
+++ b/src/anndata_to_bq.py
@@ -19,7 +19,7 @@ def dump_core_matrix(x, row_lookup, col_lookup):
     with gzip.open('cas_raw_counts.tsv.gz', 'wt') as f:
         f.write("cas_cell_index\tcas_gene_index\tdata\n")
         
-        cx = x.tocoo()    
+        cx = x.tocoo(copy=False)
         for i, j, v in zip(cx.row, cx.col, cx.data):
             cas_cell_index = row_lookup[i]
             cas_gene_index = col_lookup[j]

--- a/src/initialize_dataset.py
+++ b/src/initialize_dataset.py
@@ -36,7 +36,7 @@ def create_dataset(client, project, dataset, location):
 
 def process(project, dataset):
     # Construct a BigQuery client object.
-    client = bigquery.Client()
+    client = bigquery.Client(project=project)
     
     create_dataset(client, project, dataset, "US")
     


### PR DESCRIPTION
Only one change was actually required to be able to ingest 1 M cells, specifying `copy=False` in the `.tocoo` invocation on the raw data matrix. Likely this sidesteps a default defensive copy which becomes very expensive at this scale.

Also this only took about an hour total so it's already quite performant on a pretty large dataset. I made an attempt at using Avro but execution actually got 5x slower so I backed away from that. It's possibly I did something dumb as that was my first time Avroing, but given how performant the TSV version of this code is already I'm not sure trying again with Avro is the best use of resources in the CAS development space right now. 🙂