### PR TITLE
Write Avro, rewrite loader [VS-510]

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,46 +16,40 @@ And a larger data set
 
 [Tabula Sapiens Endothelial](https://cellxgene.cziscience.com/collections/e5f58829-1a66-40b5-a624-9046778e74f5) -  31,691 cells
 
-### Initialize BigQuery Data Set
-
-This will create the dataset, and the core data model.  If any of these exist it will continue on:
-
-```
-python src/initialize_dataset.py --project <google-project> --dataset <dataset-name>
-```
 
 ### Convert AnnData to Avro Load Format
 
-For example, to load the retina data set
+First convert from AnnData to the Avro format that will be used to load BigQuery:
 
 ```
-python src/anndata_to_bq.py --input data/horizontal-cells-in-human-retina.h5ad --cas_cell_index_start 1000 --cas_feature_index_start 5000
+python src/anndata_to_avro.py --input data/horizontal-cells-in-human-retina.h5ad --avro_prefix retina --cas_cell_index_start 1000 --cas_feature_index_start 5000
 ```
 
 NOTE: if multiple data sets are being loaded into the same dataset, offsets for the cell and feature indexes must be provided via the `cas_cell_index_start` and `cas_feature_index_start` parameters respectively.
 
-### Ingest into BigQuery
+### Initialize dataset and ingest Avro files into BigQuery
 
-Example using a specific project (gvs-internal) and dataset (mydataset).
-
-First stage the Avro files output by the step above into GCS. Specify the GCS path prefix and basename in the shell
-variables `CAS_GCS_PREFIX` and `CAS_AVRO_PREFIX`:
+Continuing this example:
 
 ```
-CAS_GCS_PREFIX=gs://mybucket/...
-CAS_AVRO_PREFIX=cas
-gsutil -m cp "${CAS_AVRO_PREFIX}*.avro" ${CAS_GCS_PREFIX}
+python src/load_cas_tables.py --project <google-project> --dataset <dataset-name> --avro_prefix retina --gcs_prefix <gcs-prefix-to-avro-files>
 ```
 
-Then specify appropriate values for `CAS_PROJECT` and `CAS_DATASET` to load into BigQuery:
+All of these parameters are required.
 
-```
-CAS_PROJECT=gvs-internal
-CAS_DATASET=mydataset
-bq load -project_id ${CAS_PROJECT} --source_format=AVRO ${CAS_DATASET}.cas_cell_info "${CAS_GCS_PREFIX}/${CAS_AVRO_PREFIX}_cell_info.avro"
-bq load -project_id ${CAS_PROJECT} --source_format=AVRO ${CAS_DATASET}.cas_feature_info "${CAS_GCS_PREFIX}/${CAS_AVRO_PREFIX}_feature_info.avro"
-bq load -project_id ${CAS_PROJECT} --source_format=AVRO ${CAS_DATASET}.cas_raw_count_matrix "${CAS_GCS_PREFIX}/${CAS_AVRO_PREFIX}_raw_counts.avro"
-```
+* `project` specifies the Google project id that will contain the BigQuery dataset.
+* `dataset` specifies the dataset name that will contain the BigQuery tables.
+* `avro_prefix` specifies the prefix used to name the output Avro from the AnnData conversion in the previous step.
+* `gcs_prefix` specifies the GCS prefix to which the Avro files should be staged for BigQuery ingestion.
+
+This step:
+
+* Creates the dataset in this specified project
+* Creates the CASP tables in the specified dataset
+* Stages the specified Avro files to the specified GCS path
+* Loads the specified tables from the specified Avro files
+* Cleans up the staged Avro files from GCS
+
 
 ### Extract Random Subset
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ NOTE: if multiple data sets are being loaded into the same dataset, offsets for 
 Continuing this example:
 
 ```
-python src/load_cas_tables.py --project <google-project> --dataset <dataset-name> --avro_prefix retina --gcs_prefix <gcs-prefix-to-avro-files>
+python src/load_dataset.py --project <google-project> --dataset <dataset-name> --avro_prefix retina --gcs_prefix <gcs-prefix-to-avro-files>
 ```
 
 All of these parameters are required.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This step:
 * Creates the dataset in this specified project
 * Creates the CASP tables in the specified dataset
 * Stages the specified Avro files to the specified GCS path
-* Loads the specified tables from the specified Avro files
+* Loads the specified tables from the staged Avro files
 * Cleans up the staged Avro files from GCS
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ CAS_AVRO_PREFIX=cas
 gsutil -m cp "${CAS_AVRO_PREFIX}*.avro" ${CAS_GCS_PREFIX}
 ```
 
-Then specify appropriate values for `CAS_PROJECT` and `CAS_DATASET` to load into BigQuery: 
+Then specify appropriate values for `CAS_PROJECT` and `CAS_DATASET` to load into BigQuery:
 
 ```
 CAS_PROJECT=gvs-internal

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy~=1.23.0
 anndata~=0.8.0
 scipy~=1.8.1
 fastavro
+pandavro

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ fastavro
 google-api-python-client
 google-cloud-bigquery
 google-cloud-storage
-numpy~=1.23.0
-scipy~=1.8.1
+numpy~=1.23.1
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ google-cloud-bigquery
 numpy~=1.23.0
 anndata~=0.8.0
 scipy~=1.8.1
+fastavro

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+anndata~=0.8.0
+fastavro
 google-api-python-client
 google-cloud-bigquery
+google-cloud-storage
 numpy~=1.23.0
-anndata~=0.8.0
 scipy~=1.8.1
-fastavro

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ numpy~=1.23.0
 anndata~=0.8.0
 scipy~=1.8.1
 fastavro
-pandavro

--- a/src/anndata_to_avro.py
+++ b/src/anndata_to_avro.py
@@ -6,6 +6,7 @@ import anndata as ad
 import argparse
 from fastavro import writer, parse_schema
 import numpy as np
+import os
 import time
 
 
@@ -140,21 +141,20 @@ def dump_feature_info(adata, filename, cas_feature_index_start):
     return col_index_to_cas_feature_index
 
 
-def check_output_files(avro_prefix):
-    file_types = ['cell_info', 'feature_info', 'raw_counts']
-    filenames = [f'{avro_prefix}_{file_type}.avro' for file_type in file_types]
-    import os
+def confirm_output_files_do_not_exist(filenames):
     existing = list(filter(lambda f: os.path.exists(f), filenames))
     if len(existing) > 0:
         raise ValueError(
             f"Found existing output files, please rename or remove before running conversion: {', '.join(existing)}")
-    return filenames
 
 
 def process(input_file, cas_cell_index_start, cas_feature_index_start, avro_prefix):
     avro_prefix = "cas" if not avro_prefix else avro_prefix
 
-    (cell_filename, feature_filename, raw_counts_filename) = check_output_files(avro_prefix)
+    file_types = ['cell_info', 'feature_info', 'raw_counts']
+    filenames = [f'{avro_prefix}_{file_type}.avro' for file_type in file_types]
+    confirm_output_files_do_not_exist(filenames)
+    (cell_filename, feature_filename, raw_counts_filename) = filenames
 
     print("Loading data...")
     adata = ad.read(input_file)

--- a/src/anndata_to_bq.py
+++ b/src/anndata_to_bq.py
@@ -6,7 +6,6 @@ import anndata as ad
 import argparse
 from fastavro import writer, parse_schema
 import numpy as np
-import pandavro as pdx
 import time
 
 
@@ -14,7 +13,7 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 
-def dump_core_matrix(x, row_lookup, col_lookup):
+def dump_core_matrix(x, row_lookup, col_lookup, basename):
     schema = {
         'doc': 'A raw datum indexed by cell and feature id in the CAS BigQuery schema',
         'namespace': 'cas',
@@ -23,7 +22,7 @@ def dump_core_matrix(x, row_lookup, col_lookup):
         'fields': [
             {'name': 'cas_cell_index', 'type': 'int'},
             {'name': 'cas_feature_index', 'type': 'int'},
-            {'name': 'data', 'type': 'int'}
+            {'name': 'raw_counts', 'type': 'int'}
         ]
     }
     parsed_schema = parse_schema(schema)
@@ -33,7 +32,7 @@ def dump_core_matrix(x, row_lookup, col_lookup):
     start = current_milli_time()
 
     # Write data to an Avro file
-    with open('cas_raw_counts.avro', 'a+b') as out:
+    with open(f'{basename}_raw_counts.avro', 'a+b') as out:
         cx = x.tocoo(copy=False)
 
         for i, j, v in zip(cx.row, cx.col, cx.data):
@@ -45,7 +44,7 @@ def dump_core_matrix(x, row_lookup, col_lookup):
             records.append({
                 u'cas_cell_index': cas_cell_index.item(),
                 u'cas_feature_index': cas_feature_index.item(),
-                u'data': v_int
+                u'raw_counts': v_int
             })
             counter = counter + 1
 
@@ -64,40 +63,110 @@ def dump_core_matrix(x, row_lookup, col_lookup):
             writer(out, parsed_schema, records)
 
 
-def process(input_file, cas_cell_index_start, cas_feature_index_start):
-    print("Loading data...")
-    adata = ad.read(input_file)
-    
+def dump_cell_info(adata, basename, cas_cell_index_start):
     # dump out cell info (obs) -- cell_id is index (26 columns)
-    print("Processing cell/observation metadata...")
-    adata.obs['original_cell_id'] = adata.obs.index    
+    adata.obs['original_cell_id'] = adata.obs.index
     adata.obs['cas_cell_index'] = np.arange(cas_cell_index_start, cas_cell_index_start + len(adata.obs))
 
     row_index_to_cas_cell_index = [None] * len(adata.obs)
     for row in range(0, len(adata.obs)):
         row_index_to_cas_cell_index[row] = adata.obs['cas_cell_index'].iloc[[row]][0]
-    
-    cells = adata.obs[['cas_cell_index', 'original_cell_id', 'cell_type']].copy()
-    cells['cell_type'] = cells.cell_type.astype(str)
-    pdx.to_avro('cas_cell_info.avro', cells)
-    
+
+    schema = {
+        'doc': 'CAS Cell Info',
+        'namespace': 'cas',
+        'name': 'CellInfo',
+        'type': 'record',
+        'fields': [
+            {'name': 'cas_cell_index', 'type': 'int'},
+            {'name': 'original_cell_id', 'type': 'string'},
+            {'name': 'cell_type', 'type': 'string'}
+        ]
+    }
+
+    parsed_schema = parse_schema(schema)
+    records = []
+    counter = 0
+
+    with open(f'{basename}_cell_info.avro', 'a+b') as out:
+        cells = adata.obs[['cas_cell_index', 'original_cell_id', 'cell_type']]
+        for _, row in cells.iterrows():
+            counter = counter + 1
+            records.append({
+                u'cas_cell_index': row['cas_cell_index'],
+                u'original_cell_id': row['original_cell_id'],
+                u'cell_type': row['cell_type']
+            })
+
+            if counter % 10000 == 0:
+                writer(out, parsed_schema, records)
+                records = []
+
+        if len(records) > 0:
+            writer(out, parsed_schema, records)
+
+    return row_index_to_cas_cell_index
+
+
+def dump_feature_info(adata, basename, cas_feature_index_start):
     # dump out feature info -- feature_id is index (12 columns)
-    print("Processing feature/gene/variable metadata...")
     adata.var['original_feature_id'] = adata.var.index
-    
+
     adata.var['cas_feature_index'] = np.arange(cas_feature_index_start, cas_feature_index_start + len(adata.var))
     col_index_to_cas_feature_index = [None] * len(adata.var)
     for col in range(0, len(adata.var)):
         col_index_to_cas_feature_index[col] = adata.var['cas_feature_index'].iloc[[col]][0]
-    
-    features = adata.var[['cas_feature_index', 'original_feature_id', 'feature_name']].copy()
-    features['feature_name'] = features.feature_name.astype(str)
-    pdx.to_avro('cas_feature_info.avro', features)
-    
+
+    schema = {
+        'doc': 'CAS Feature Info',
+        'namespace': 'cas',
+        'name': 'FeatureInfo',
+        'type': 'record',
+        'fields': [
+            {'name': 'cas_feature_index', 'type': 'int'},
+            {'name': 'original_feature_id', 'type': 'string'},
+            {'name': 'feature_name', 'type': 'string'}
+        ]
+    }
+
+    parsed_schema = parse_schema(schema)
+    records = []
+    counter = 0
+
+    with open(f'{basename}_feature_info.avro', 'a+b') as out:
+        features = adata.var[['cas_feature_index', 'original_feature_id', 'feature_name']]
+        for _, row in features.iterrows():
+            counter = counter + 1
+            records.append({
+                u'cas_feature_index': row['cas_feature_index'],
+                u'original_feature_id': row['original_feature_id'],
+                u'feature_name': row['feature_name']
+            })
+
+            if counter % 10000 == 0:
+                writer(out, parsed_schema, records)
+                records = []
+
+        if len(records) > 0:
+            writer(out, parsed_schema, records)
+
+    return col_index_to_cas_feature_index
+
+
+def process(input_file, cas_cell_index_start, cas_feature_index_start, basename):
+    basename = "cas" if not basename else basename
+    print("Loading data...")
+    adata = ad.read(input_file)
+
+    print("Processing cell/observation metadata...")
+    row_index_to_cas_cell_index = dump_cell_info(adata, basename, cas_cell_index_start)
+    # dump out feature info -- feature_id is index (12 columns)
+    print("Processing feature/gene/variable metadata...")
+    col_index_to_cas_feature_index = dump_feature_info(adata, basename, cas_feature_index_start)
+
     print("Processing core data...")
-    
     # recode the indexes to be the indexes of obs/var or should obs/var include these indices?
-    dump_core_matrix(adata.raw.X, row_index_to_cas_cell_index, col_index_to_cas_feature_index)
+    dump_core_matrix(adata.raw.X, row_index_to_cas_cell_index, col_index_to_cas_feature_index, basename)
         
 # TODO: naive dump, compare
 #    rows,cols = adata.X.nonzero()
@@ -113,6 +182,8 @@ if __name__ == '__main__':
         description='Convert AnnData Single Cell Expression Data into format for loading into BQ')
 
     parser.add_argument('--input', type=str, help='AnnData format input file', required=True)
+    parser.add_argument('--basename', type=str,
+                        help='Base filename to use for output files, e.g. <base>_cell_info.avro etc', required=False)
     parser.add_argument('--cas_cell_index_start', type=int, help='starting number for cell index', required=False,
                         default=0)
     parser.add_argument('--cas_feature_index_start', type=int, help='starting number for feature index', required=False,
@@ -121,4 +192,4 @@ if __name__ == '__main__':
     # Execute the parse_args() method
     args = parser.parse_args()
 
-    process(args.input, args.cas_cell_index_start, args.cas_feature_index_start)
+    process(args.input, args.cas_cell_index_start, args.cas_feature_index_start, args.basename)

--- a/src/anndata_to_bq.py
+++ b/src/anndata_to_bq.py
@@ -13,7 +13,29 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 
-def dump_core_matrix(x, row_lookup, col_lookup, basename):
+def write_avro(generator, parsed_schema, filename, flush_batch_size, progress_batch_size):
+    start = current_milli_time()
+    with open(filename, 'a+b') as out:
+        records = []
+        counter = 0
+        for record in generator():
+            counter = counter + 1
+            records.append(record)
+
+            if counter % flush_batch_size == 0:
+                writer(out, parsed_schema, records)
+                records = []
+
+            if counter % progress_batch_size == 0:
+                end = current_milli_time()
+                print(f"    Processed {counter} rows... in {end-start} ms")
+                start = end
+
+        if len(records) > 0:
+            writer(out, parsed_schema, records)
+
+
+def dump_core_matrix(x, row_lookup, col_lookup, basename, flush_batch_size, progress_batch_size):
     schema = {
         'doc': 'A raw datum indexed by cell and feature id in the CAS BigQuery schema',
         'namespace': 'cas',
@@ -27,12 +49,7 @@ def dump_core_matrix(x, row_lookup, col_lookup, basename):
     }
     parsed_schema = parse_schema(schema)
 
-    counter = 0
-    records = []
-    start = current_milli_time()
-
-    # Write data to an Avro file
-    with open(f'{basename}_raw_counts.avro', 'a+b') as out:
+    def raw_counts_generator():
         cx = x.tocoo(copy=False)
 
         for i, j, v in zip(cx.row, cx.col, cx.data):
@@ -41,30 +58,18 @@ def dump_core_matrix(x, row_lookup, col_lookup, basename):
             
             # Todo -- how can we ensure this is safe/right?
             v_int = int(v)
-            records.append({
+            yield {
                 u'cas_cell_index': cas_cell_index.item(),
                 u'cas_feature_index': cas_feature_index.item(),
                 u'raw_counts': v_int
-            })
-            counter = counter + 1
+            }
 
-            # Write in batches for reasonable performance, one by one is extremely slow.
-            if counter % 10000 == 0:
-                writer(out, parsed_schema, records)
-                records = []
-
-            if counter % 1000000 == 0:
-                end = current_milli_time()
-                print(f"    Processed {counter} rows... in {end-start} ms")
-                start = end
-
-        # Write any leftover records.
-        if len(records) > 0:
-            writer(out, parsed_schema, records)
+    write_avro(raw_counts_generator, parsed_schema, f'{basename}_raw_counts.avro',
+               flush_batch_size, progress_batch_size)
 
 
-def dump_cell_info(adata, basename, cas_cell_index_start):
-    # dump out cell info (obs) -- cell_id is index (26 columns)
+def dump_cell_info(adata, basename, cas_cell_index_start, flush_batch_size, progress_batch_size):
+    # Dump out cell info (obs) -- cell_id is index (26 columns).
     adata.obs['original_cell_id'] = adata.obs.index
     adata.obs['cas_cell_index'] = np.arange(cas_cell_index_start, cas_cell_index_start + len(adata.obs))
 
@@ -95,28 +100,14 @@ def dump_cell_info(adata, basename, cas_cell_index_start):
                 u'cell_type': r['cell_type']
             }
 
-    def write_cells(generator, filename):
-        with open(filename, 'a+b') as out:
-            records = []
-            counter = 0
-            for record in generator():
-                counter = counter + 1
-                records.append(record)
-
-                if counter % 10000 == 0:
-                    writer(out, parsed_schema, records)
-                    records = []
-
-            if len(records) > 0:
-                writer(out, parsed_schema, records)
-
-    write_cells(cell_generator, f'{basename}_cell_info.avro')
+    write_avro(cell_generator, parsed_schema, f'{basename}_cell_info.avro',
+               flush_batch_size, progress_batch_size)
 
     return row_index_to_cas_cell_index
 
 
-def dump_feature_info(adata, basename, cas_feature_index_start):
-    # dump out feature info -- feature_id is index (12 columns)
+def dump_feature_info(adata, basename, cas_feature_index_start, flush_batch_size, progress_batch_size):
+    # Dump out feature info -- feature_id is index (12 columns).
     adata.var['original_feature_id'] = adata.var.index
 
     adata.var['cas_feature_index'] = np.arange(cas_feature_index_start, cas_feature_index_start + len(adata.var))
@@ -137,43 +128,40 @@ def dump_feature_info(adata, basename, cas_feature_index_start):
     }
 
     parsed_schema = parse_schema(schema)
-    records = []
-    counter = 0
 
-    with open(f'{basename}_feature_info.avro', 'a+b') as out:
+    def feature_generator():
         features = adata.var[['cas_feature_index', 'original_feature_id', 'feature_name']]
         for _, row in features.iterrows():
-            counter = counter + 1
-            records.append({
+            yield {
                 u'cas_feature_index': row['cas_feature_index'],
                 u'original_feature_id': row['original_feature_id'],
                 u'feature_name': row['feature_name']
-            })
+            }
 
-            if counter % 10000 == 0:
-                writer(out, parsed_schema, records)
-                records = []
-
-        if len(records) > 0:
-            writer(out, parsed_schema, records)
-
+    write_avro(feature_generator, parsed_schema, f'{basename}_feature_info.avro',
+               flush_batch_size, progress_batch_size)
     return col_index_to_cas_feature_index
 
 
-def process(input_file, cas_cell_index_start, cas_feature_index_start, basename):
+def process(input_file, cas_cell_index_start, cas_feature_index_start, basename, flush_batch_size, progress_batch_size):
     basename = "cas" if not basename else basename
+    flush_batch_size = 10000 if not flush_batch_size else flush_batch_size
+    progress_batch_size = 1000000 if not progress_batch_size else progress_batch_size
     print("Loading data...")
     adata = ad.read(input_file)
 
     print("Processing cell/observation metadata...")
-    row_index_to_cas_cell_index = dump_cell_info(adata, basename, cas_cell_index_start)
+    row_index_to_cas_cell_index = dump_cell_info(adata, basename, cas_cell_index_start,
+                                                 flush_batch_size, progress_batch_size)
     # dump out feature info -- feature_id is index (12 columns)
     print("Processing feature/gene/variable metadata...")
-    col_index_to_cas_feature_index = dump_feature_info(adata, basename, cas_feature_index_start)
+    col_index_to_cas_feature_index = dump_feature_info(adata, basename, cas_feature_index_start,
+                                                       flush_batch_size, progress_batch_size)
 
     print("Processing core data...")
     # recode the indexes to be the indexes of obs/var or should obs/var include these indices?
-    dump_core_matrix(adata.raw.X, row_index_to_cas_cell_index, col_index_to_cas_feature_index, basename)
+    dump_core_matrix(adata.raw.X, row_index_to_cas_cell_index, col_index_to_cas_feature_index, basename,
+                     flush_batch_size, progress_batch_size)
         
 # TODO: naive dump, compare
 #    rows,cols = adata.X.nonzero()
@@ -195,8 +183,12 @@ if __name__ == '__main__':
                         default=0)
     parser.add_argument('--cas_feature_index_start', type=int, help='starting number for feature index', required=False,
                         default=0)
+    parser.add_argument('--flush_batch_size', type=int, help='max size of Avro batches to flush', required=False)
+    parser.add_argument('--progress_batch_size', type=int, help='size of batches on which to report progress',
+                        required=False)
 
     # Execute the parse_args() method
     args = parser.parse_args()
 
-    process(args.input, args.cas_cell_index_start, args.cas_feature_index_start, args.basename)
+    process(args.input, args.cas_cell_index_start, args.cas_feature_index_start, args.basename,
+            args.flush_batch_size, args.progress_batch_size)

--- a/src/load_dataset.py
+++ b/src/load_dataset.py
@@ -2,6 +2,7 @@ import argparse
 from google.api_core.exceptions import Conflict
 from google.cloud import bigquery
 from google.cloud import storage
+import os
 
 
 def create_table(client, project, dataset, tablename, schema, clustering_fields):
@@ -38,7 +39,6 @@ def create_dataset(client, project, dataset, location):
 def check_avro_files_exist(avro_prefix):
     file_types = ['cell_info', 'feature_info', 'raw_counts']
     filenames = [f'{avro_prefix}_{file_type}.avro' for file_type in file_types]
-    import os
     missing = list(filter(lambda f: not os.path.exists(f), filenames))
     if len(missing) > 0:
         raise ValueError(

--- a/src/load_dataset.py
+++ b/src/load_dataset.py
@@ -139,7 +139,7 @@ if __name__ == '__main__':
     parser.add_argument('--dataset', type=str, help='BigQuery Dataset', required=True)
     parser.add_argument('--avro_prefix', type=str, help='Prefix with which Avro files are named', required=True)
     parser.add_argument('--gcs_prefix', type=str, help='GCS prefix to which Avro files should be staged', required=True)
-    parser.add_argument('--force_bq_append', type=str,
+    parser.add_argument('--force_bq_append', type=bool,
                         help='Append data to BigQuery tables even if data some data is already loaded', required=False)
 
     # Execute the parse_args() method


### PR DESCRIPTION
Despite what the diffs say the two Python files here are not new, they're just heavily revised and renamed. `anndata_to_avro.py` now writes Avro  instead of TSV. h/t `fastavro` for making this Avro export run ~2x faster than TSV export. The loading process has also been streamlined to tack the actual loading of BQ tables onto the dataset and table creation process, so now there are only two steps:

```
$ python src/load_dataset.py --project gvs-internal --dataset retinal_all_major --avro_prefix retinal_all_major --gcs_prefix gs://gvs-internal-space/scratch
Created dataset gvs-internal.Dataset(DatasetReference('gvs-internal', 'retinal_all_major')).
Created 'gvs-internal.retinal_all_major.cas_cell_info'.
Created 'gvs-internal.retinal_all_major.cas_feature_info'.
Created 'gvs-internal.retinal_all_major.cas_raw_count_matrix'.
Staged 'retinal_all_major_cell_info.avro' to 'gs://gvs-internal-space/scratch/retinal_all_major_cell_info.avro'.
244474 rows loaded into BigQuery table 'gvs-internal.retinal_all_major.cas_cell_info'.
Staged 'retinal_all_major_feature_info.avro' to 'gs://gvs-internal-space/scratch/retinal_all_major_feature_info.avro'.
30933 rows loaded into BigQuery table 'gvs-internal.retinal_all_major.cas_feature_info'.
Staged 'retinal_all_major_raw_counts.avro' to 'gs://gvs-internal-space/scratch/retinal_all_major_raw_counts.avro'.
547439817 rows loaded into BigQuery table 'gvs-internal.retinal_all_major.cas_raw_count_matrix'.
Removed staged file 'gs://gvs-internal-space/scratch/retinal_all_major_raw_counts.avro'.
Removed staged file 'gs://gvs-internal-space/scratch/retinal_all_major_raw_counts.avro'.
Removed staged file 'gs://gvs-internal-space/scratch/retinal_all_major_raw_counts.avro'.
Done.
$
```