### PR TITLE
Use JSON columns for metadata [VS-546]

### DIFF
--- a/src/casp/anndata_to_avro.py
+++ b/src/casp/anndata_to_avro.py
@@ -108,7 +108,7 @@ def dump_cell_info(adata, filename, cas_cell_index_start, ingest_id):
             {"name": "cas_cell_index", "type": "int"},
             {"name": "original_cell_id", "type": "string"},
             {"name": "cell_type", "type": "string"},
-            {'name': 'obs_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
+            {"name": "obs_metadata", "type": {"type": "string", "sqlType": "JSON"}},
             {"name": "cas_ingest_id", "type": "string"},
         ],
     }
@@ -154,7 +154,7 @@ def dump_feature_info(adata, filename, cas_feature_index_start, ingest_id):
             {"name": "cas_feature_index", "type": "int"},
             {"name": "original_feature_id", "type": "string"},
             {"name": "feature_name", "type": "string"},
-            {'name': 'var_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
+            {"name": "var_metadata", "type": {"type": "string", "sqlType": "JSON"}},
             {"name": "cas_ingest_id", "type": "string"},
         ],
     }
@@ -190,7 +190,7 @@ def dump_ingest_info(adata, filename, ingest_id):
         "type": "record",
         "fields": [
             {"name": "cas_ingest_id", "type": "string"},
-            {'name': 'uns_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
+            {"name": "uns_metadata", "type": {"type": "string", "sqlType": "JSON"}},
             {"name": "ingest_timestamp", "type": ["null", "long"], "logicalType": ["null", "timestamp-millis"]},
         ],
     }

--- a/src/casp/anndata_to_avro.py
+++ b/src/casp/anndata_to_avro.py
@@ -28,7 +28,7 @@ def current_milli_time():
     return round(time.time() * 1000)
 
 
-def write_avro(generator, parsed_schema, filename, progress_batch_size=1000):
+def write_avro(generator, parsed_schema, filename, progress_batch_size=10000):
     """
     Avro writing worker function. Calls back to `generator` for each row to be written.
     """
@@ -108,26 +108,7 @@ def dump_cell_info(adata, filename, cas_cell_index_start, ingest_id):
             {"name": "cas_cell_index", "type": "int"},
             {"name": "original_cell_id", "type": "string"},
             {"name": "cell_type", "type": "string"},
-            # {'name': 'obs_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
-            #
-            # https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#extract_json_data_from_avro_data
-            # https://cloud.google.com/bigquery/docs/reference/standard-sql/json-data#use_a_batch_load_job
-            #
-            # It would be great to store JSON-formatted metadata into a JSON column rather than a string column. But
-            # despite what the documentation above says I see "Unsupported field type: JSON" errors like the following
-            # using either the Python API or `bq load` when the CAS tables have JSON metadata fields:
-            #
-            # Traceback (most recent call last):
-            #   File "/blah/gitrepos/cell-annotation-service-pilot/src/load_dataset.py", line 193, in <module>
-            #     process(args.project, args.dataset, args.avro_prefix, args.gcs_path_prefix, args.force_bq_append)
-            #   File "/blah/gitrepos/cell-annotation-service-pilot/src/load_dataset.py", line 164, in process
-            #     load_job.result()  # Waits for the job to complete.
-            #   File "/blah/gitrepos/cell-annotation-service-pilot/venv/lib/python3.10/site-packages/google/cloud/bigquery/job/base.py", line 728, in result
-            #     return super(_AsyncJob, self).result(timeout=timeout, **kwargs)
-            #   File "/blah/gitrepos/cell-annotation-service-pilot/venv/lib/python3.10/site-packages/google/api_core/future/polling.py", line 137, in result
-            #     raise self._exception
-            # google.api_core.exceptions.BadRequest: 400 Unsupported field type: JSON
-            {"name": "obs_metadata", "type": "string"},
+            {'name': 'obs_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
             {"name": "cas_ingest_id", "type": "string"},
         ],
     }
@@ -173,9 +154,7 @@ def dump_feature_info(adata, filename, cas_feature_index_start, ingest_id):
             {"name": "cas_feature_index", "type": "int"},
             {"name": "original_feature_id", "type": "string"},
             {"name": "feature_name", "type": "string"},
-            # See remarks at `dump_cell_info` regarding BQ JSON field issues.
-            # {'name': 'var_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
-            {"name": "var_metadata", "type": "string"},
+            {'name': 'var_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
             {"name": "cas_ingest_id", "type": "string"},
         ],
     }
@@ -211,9 +190,7 @@ def dump_ingest_info(adata, filename, ingest_id):
         "type": "record",
         "fields": [
             {"name": "cas_ingest_id", "type": "string"},
-            # See remarks at `dump_cell_info` regarding BQ JSON field issues.
-            # {'name': 'uns_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
-            {"name": "uns_metadata", "type": "string"},
+            {'name': 'uns_metadata', 'type': {'type': 'string', 'sqlType': 'JSON'}},
             {"name": "ingest_timestamp", "type": ["null", "long"], "logicalType": ["null", "timestamp-millis"]},
         ],
     }

--- a/src/casp/load_dataset.py
+++ b/src/casp/load_dataset.py
@@ -87,9 +87,7 @@ def create_bigquery_objects(client, project, dataset):
         "cas_ingest_info",
         [
             bigquery.SchemaField("cas_ingest_id", "STRING", mode="REQUIRED"),
-            # TODO get direct JSON metadata loading working
-            # bigquery.SchemaField("uns_metadata", "JSON", mode="REQUIRED"),
-            bigquery.SchemaField("uns_metadata", "STRING", mode="REQUIRED"),
+            bigquery.SchemaField("uns_metadata", "JSON", mode="REQUIRED"),
             bigquery.SchemaField("ingest_timestamp", "TIMESTAMP", mode="NULLABLE"),
         ],
         [],
@@ -104,9 +102,7 @@ def create_bigquery_objects(client, project, dataset):
             bigquery.SchemaField("cas_cell_index", "INTEGER", mode="REQUIRED"),
             bigquery.SchemaField("original_cell_id", "STRING", mode="REQUIRED"),
             bigquery.SchemaField("cell_type", "STRING", mode="REQUIRED"),
-            # TODO get direct JSON metadata loading working
-            # bigquery.SchemaField("obs_metadata", "JSON", mode="REQUIRED"),
-            bigquery.SchemaField("obs_metadata", "STRING", mode="REQUIRED"),
+            bigquery.SchemaField("obs_metadata", "JSON", mode="REQUIRED"),
             bigquery.SchemaField("cas_ingest_id", "STRING", mode="REQUIRED"),
         ],
         [],
@@ -121,9 +117,7 @@ def create_bigquery_objects(client, project, dataset):
             bigquery.SchemaField("cas_feature_index", "INTEGER", mode="REQUIRED"),
             bigquery.SchemaField("original_feature_id", "STRING", mode="REQUIRED"),
             bigquery.SchemaField("feature_name", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("var_metadata", "STRING", mode="REQUIRED"),
-            # TODO get direct JSON metadata loading working
-            # bigquery.SchemaField("var_metadata", "JSON", mode="REQUIRED"),
+            bigquery.SchemaField("var_metadata", "JSON", mode="REQUIRED"),
             bigquery.SchemaField("cas_ingest_id", "STRING", mode="REQUIRED"),
         ],
         [],


### PR DESCRIPTION
Per discussion with Google, the previous situation of being unable to load JSON columns from Avro files is a bug which Google was aware of and for which a fix is currently being rolled out. The fix is expected to become generally available in one to two weeks, but in the meantime projects must be put on an "allow list" in order for JSON column loading from Avro files to work. Our `gvs-internal` project has been allowlisted so this code works fine there, but `broad-dsp-spec-ops` has not been allowlisted so this code does not work there.