### PR TITLE
include match summary stats, updated output JSON

### DIFF
--- a/src/casp/api/server.py
+++ b/src/casp/api/server.py
@@ -88,13 +88,13 @@ def __get_cell_type_distribution(query_ids, knn_response):
 
     __log("Querying Match Cell Metadata")
     query = f"""
-                SELECT t.query_id, 
-                       ci.cell_type, 
-                       MIN(t.match_score) min_distance, 
-                       MAX(t.match_score) max_distance,   
-                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(25)] as p25_distance,   
-                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(50)] as median_distance,  
-                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(75)] as p75_distance,   
+                SELECT t.query_id,
+                       ci.cell_type,
+                       MIN(t.match_score) min_distance,
+                       MAX(t.match_score) max_distance,
+                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(25)] as p25_distance,
+                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(50)] as median_distance,
+                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(75)] as p75_distance,
                        COUNT(*) cell_count
                 FROM `{temp_table_fqn}` t
                 JOIN `{settings.bq_cell_info_table_fqn}` ci ON t.match_cas_cell_index = ci.cas_cell_index

--- a/src/casp/api/server.py
+++ b/src/casp/api/server.py
@@ -1,7 +1,6 @@
 import typing as t
 import uuid
 from datetime import datetime, timedelta
-import json
 
 import pandas as pd
 import requests

--- a/src/casp/api/server.py
+++ b/src/casp/api/server.py
@@ -109,19 +109,19 @@ def __get_cell_type_distribution(query_ids, knn_response):
     # TODO: use a StreamingResponse and yield/generator pattern here to avoid building entire response in memory, also compress
     # Stream results back in JSONL format (https://jsonlines.org/)
     results = []
-    
+
     last_query_id = None
-    data = {}    
+    data = {}
     for row in query_job:
         if last_query_id is None or last_query_id != row["query_id"]:
             # emit data and reset state if this isn't the first time through
             if last_query_id is not None:
                 results.append(data)
 
-            data = {}     
-            data['query_cell_id'] = row["query_id"]
-            data['matches'] = []
-            last_query_id = data['query_cell_id']
+            data = {}
+            data["query_cell_id"] = row["query_id"]
+            data["matches"] = []
+            last_query_id = data["query_cell_id"]
 
         x = {}
         x["cell_type"] = row["cell_type"]
@@ -131,12 +131,12 @@ def __get_cell_type_distribution(query_ids, knn_response):
         x["median_distance"] = row["median_distance"]
         x["p75_distance"] = row["p75_distance"]
         x["max_distance"] = row["max_distance"]
-        data['matches'].append(x)
-        
+        data["matches"].append(x)
+
     # handle final output
     results.append(data)
 
-    # and return       
+    # and return
     return results
 
 

--- a/src/casp/api/server.py
+++ b/src/casp/api/server.py
@@ -1,4 +1,3 @@
-import typing as t
 import uuid
 from datetime import datetime, timedelta
 

--- a/src/casp/api/server.py
+++ b/src/casp/api/server.py
@@ -1,6 +1,7 @@
 import typing as t
 import uuid
 from datetime import datetime, timedelta
+import json
 
 import pandas as pd
 import requests
@@ -89,23 +90,53 @@ def __get_cell_type_distribution(query_ids, knn_response):
 
     __log("Querying Match Cell Metadata")
     query = f"""
-                SELECT t.query_id, ci.cell_type, avg(t.match_score), count(*) cell_count
+                SELECT t.query_id, 
+                       ci.cell_type, 
+                       MIN(t.match_score) min_distance, 
+                       MAX(t.match_score) max_distance,   
+                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(25)] as p25_distance,   
+                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(50)] as median_distance,  
+                       APPROX_QUANTILES(t.match_score, 100)[SAFE_ORDINAL(75)] as p75_distance,   
+                       COUNT(*) cell_count
                 FROM `{temp_table_fqn}` t
                 JOIN `{settings.bq_cell_info_table_fqn}` ci ON t.match_cas_cell_index = ci.cas_cell_index
                 GROUP BY 1,2
-                ORDER BY 1, 3 DESC
+                ORDER BY 1, 8 DESC
                 """
 
     query_job = bq_client.query(query)
 
-    results = {}
+    # TODO: use a StreamingResponse and yield/generator pattern here to avoid building entire response in memory, also compress
+    # Stream results back in JSONL format (https://jsonlines.org/)
+    results = []
+    
+    last_query_id = None
+    data = {}    
     for row in query_job:
-        query_id = row["query_id"]
-        if query_id not in results:
-            results[query_id] = {}
+        if last_query_id is None or last_query_id != row["query_id"]:
+            # emit data and reset state if this isn't the first time through
+            if last_query_id is not None:
+                results.append(data)
 
-        results[query_id][row["cell_type"]] = row["cell_count"]
+            data = {}     
+            data['query_cell_id'] = row["query_id"]
+            data['matches'] = []
+            last_query_id = data['query_cell_id']
 
+        x = {}
+        x["cell_type"] = row["cell_type"]
+        x["cell_count"] = row["cell_count"]
+        x["min_distance"] = row["min_distance"]
+        x["p25_distance"] = row["p25_distance"]
+        x["median_distance"] = row["median_distance"]
+        x["p75_distance"] = row["p75_distance"]
+        x["max_distance"] = row["max_distance"]
+        data['matches'].append(x)
+        
+    # handle final output
+    results.append(data)
+
+    # and return       
     return results
 
 
@@ -129,7 +160,7 @@ async def root() -> str:
 
 
 @app.post("/annotate")
-async def annotate(myfile: UploadFile, json: str = Form()) -> t.Dict:
+async def annotate(myfile: UploadFile, json: str = Form()):
     return __annotate(myfile.file)
 
 


### PR DESCRIPTION
Calculate additional summary stats and updated output JSON format.  For example:

```
{
    "query_cell_id": "99759",
    "matches": [
      {
        "cell_type": "erythrocyte",
        "cell_count": 94,
        "min_distance": 1589.847900390625,
        "p25_distance": 1664.875244140625,
        "median_distance": 1791.372802734375,
        "p75_distance": 1801.3585205078125,
        "max_distance": 1840.047119140625
      },
      {
        "cell_type": "monocyte",
        "cell_count": 3,
        "min_distance": 1716.2490234375,
        "p25_distance": 1716.2490234375,
        "median_distance": 1804.897216796875,
        "p75_distance": 1841.0843505859375,
        "max_distance": 1841.0843505859375
      },
      {
        "cell_type": "erythroid progenitor cell",
        "cell_count": 3,
        "min_distance": 1462.53955078125,
        "p25_distance": 1462.53955078125,
        "median_distance": 1693.428955078125,
        "p75_distance": 1788.7325439453125,
        "max_distance": 1788.7325439453125
      }
    ]
  }
```