### PR TITLE
fix: #212 fix model inference batch keys

### DIFF
--- a/cellarium/cas_backend/apps/admin/views.py
+++ b/cellarium/cas_backend/apps/admin/views.py
@@ -390,6 +390,7 @@ class CASVectorIndexAdminView(CellariumCloudAdminModelView):
         "distance_metric",
         "nprobe",
         "l_search",
+        "memory_budget",
         "model",
     )
     column_descriptions = {
@@ -401,6 +402,9 @@ class CASVectorIndexAdminView(CellariumCloudAdminModelView):
         "distance_metric": "Distance metric used when the index was built: cosine, l2, or dot_product.",
         "nprobe": "Required for IVF_FLAT indexes. Must be empty otherwise.",
         "l_search": "Required for VAMANA indexes. Must be empty otherwise.",
+        "memory_budget": (
+            "Optional memory budget in bytes for loading the TileDB index. Leave empty to use the TileDB default."
+        ),
     }
     form_choices = {
         "index_type": [(m.value, m.value) for m in IndexType],

--- a/cellarium/cas_backend/apps/compute/vector_search/tiledb.py
+++ b/cellarium/cas_backend/apps/compute/vector_search/tiledb.py
@@ -33,6 +33,7 @@ class TileDBIndexConfig:
     distance_metric: DistanceMetric
     nprobe: int | None
     l_search: int | None
+    memory_budget: int | None
 
 
 def _get_index_class(index_type: IndexType):
@@ -83,15 +84,19 @@ def validate_tiledb_index(index: models.CASVectorIndex) -> TileDBIndexConfig:
         distance_metric=distance_metric,
         nprobe=index.nprobe,
         l_search=index.l_search,
+        memory_budget=index.memory_budget,
     )
 
 
-def _get_cached_index(index_uri: str, index_type: str):
+def _get_cached_index(index_uri: str, index_type: str, memory_budget: int | None):
     if index_uri in _INDEX_CACHE:
         return _INDEX_CACHE[index_uri]
 
     index_class = _get_index_class(index_type)
-    index_obj = index_class(uri=index_uri)
+    kwargs: dict[str, t.Any] = {"uri": index_uri}
+    if memory_budget is not None:
+        kwargs["memory_budget"] = memory_budget
+    index_obj = index_class(**kwargs)
 
     _INDEX_CACHE[index_uri] = index_obj
     return index_obj
@@ -140,6 +145,7 @@ class TileDBVectorSearch:
         self.index_obj = _get_cached_index(
             index_uri=self.index_config.index_uri,
             index_type=self.index_config.index_type,
+            memory_budget=self.index_config.memory_budget,
         )
 
         dimensions = self.index_obj.get_dimensions()

--- a/cellarium/cas_backend/apps/model_inference/services.py
+++ b/cellarium/cas_backend/apps/model_inference/services.py
@@ -10,6 +10,7 @@ from cellarium.cas_backend.apps.model_inference import exceptions
 from cellarium.cas_backend.core.config import settings
 from cellarium.cas_backend.core.db import models
 from cellarium.ml import CellariumAnnDataDataModule, CellariumModule
+from cellarium.ml.utilities.data import AnnDataField, densify
 
 
 class ModelInferenceService:
@@ -27,9 +28,9 @@ class ModelInferenceService:
         """
         return f"gs://{settings.PROJECT_BUCKET_NAME}/{model_checkpoint_file_path}"
 
-    @staticmethod
+    @classmethod
     @cache
-    def _get_model_checkpoint_file(model_file_path: str) -> t.BinaryIO:
+    def _get_model_checkpoint_file(cls, model_file_path: str) -> t.BinaryIO:
         """
         Get model checkpoint from either local or GCS and load it using CellariumModule.
 
@@ -37,14 +38,14 @@ class ModelInferenceService:
 
         :return: CellariumModule object
         """
-        model_checkpoint_path = ModelInferenceService._get_model_checkpoint_path(model_file_path)
+        model_checkpoint_path = cls._get_model_checkpoint_path(model_file_path)
 
         with open(model_checkpoint_path, "rb") as model_checkpoint_file:
             return BytesIO(model_checkpoint_file.read())
 
-    @staticmethod
+    @classmethod
     @cache
-    def _load_module_from_checkpoint(model_file_path: str) -> CellariumModule:
+    def _load_module_from_checkpoint(cls, model_file_path: str) -> CellariumModule:
         """
         Load CellariumModule from checkpoint file.
 
@@ -52,7 +53,7 @@ class ModelInferenceService:
 
         :return: CellariumModule object
         """
-        checkpoint_file = ModelInferenceService._get_model_checkpoint_file(model_file_path)
+        checkpoint_file = cls._get_model_checkpoint_file(model_file_path)
 
         return CellariumModule.load_from_checkpoint(checkpoint_file, map_location="cpu")
 
@@ -72,6 +73,28 @@ class ModelInferenceService:
             "module_cache_info": module_cache_info,
         }
 
+    @staticmethod
+    def _create_cellarium_data_module(adata: anndata.AnnData) -> CellariumAnnDataDataModule:
+        """
+        Create CellariumAnnDataDataModule from anndata object that is ready to be used for model inference.
+
+        :param adata: Anndata object
+
+        :return: CellariumAnnDataDataModule
+        """
+        data_module = CellariumAnnDataDataModule(
+            dadc=adata,
+            batch_keys={
+                "x_ng": AnnDataField(attr="X", convert_fn=densify),
+                "var_names_g": AnnDataField(attr="var_names"),
+                "total_mrna_umis_n": AnnDataField(attr="obs", key="total_mrna_umis"),
+            },
+            batch_size=len(adata),
+            shuffle=False,
+        )
+        data_module.setup(stage="predict")
+        return data_module
+
     def _get_output_from_model(self, model: models.CASModel, adata: anndata.AnnData) -> tuple[np.ndarray, list[str]]:
         """
         Get output from cellarium-ml model that predicts embeddings given an input adata.
@@ -83,12 +106,7 @@ class ModelInferenceService:
         """
         cellarium_module = ModelInferenceService._load_module_from_checkpoint(model.model_file_path)
 
-        cellarium_checkpoint_file = ModelInferenceService._get_model_checkpoint_file(model.model_file_path)
-        cellarium_checkpoint_file.seek(0)
-        cellarium_data_module = CellariumAnnDataDataModule.load_from_checkpoint(
-            cellarium_checkpoint_file, dadc=adata, batch_size=adata.n_obs, num_workers=0
-        )
-        cellarium_data_module.setup(stage="predict")
+        cellarium_data_module = self._create_cellarium_data_module(adata=adata)
         batch = next(iter(cellarium_data_module.predict_dataloader()))
 
         cellarium_output_dict = cellarium_module(batch)

--- a/cellarium/cas_backend/core/config.py
+++ b/cellarium/cas_backend/core/config.py
@@ -23,7 +23,7 @@ class AllEnvSettings(BaseSettings):
     # General
     GOOGLE_ACCOUNT_CREDENTIALS: dict = json.loads(os.environ.get("GOOGLE_SERVICE_ACCOUNT_CREDENTIALS", "{}"))
     ENVIRONMENT: str = ENV_TYPE
-    APP_VERSION: str = "1.8.2"
+    APP_VERSION: str = "1.8.3"
     APP_ROOT: str = REPO_ROOT
     DEFAULT_FEATURE_SCHEMA: str = "refdata-gex-GRCh38-2020-A"
     PROJECT_BUCKET_NAME: str | None = os.environ.get("PROJECT_BUCKET_NAME")

--- a/cellarium/cas_backend/core/config.py
+++ b/cellarium/cas_backend/core/config.py
@@ -57,7 +57,7 @@ class AllEnvSettings(BaseSettings):
     API_REQUEST_TEMP_TABLE_DATASET_EXPIRATION: int = 10  # 10 minutes
     KNN_SEARCH_NUM_MATCHES_DEFAULT: int = 100
     ITEMS_PER_USER: int = 50
-    UVICORN_WORKERS: int = 2
+    UVICORN_WORKERS: int = 1
     MAX_CELL_IDS_PER_QUERY: int = 20_000  # Maximum number of cell IDs that can be queried at once
     # Consensus Engine
     # Auth

--- a/cellarium/cas_backend/core/db/migrations/versions/t_2026-04-15_00-00-00_add_memory_budget_to_vector_index.py
+++ b/cellarium/cas_backend/core/db/migrations/versions/t_2026-04-15_00-00-00_add_memory_budget_to_vector_index.py
@@ -1,0 +1,24 @@
+"""add_memory_budget_to_vector_index
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-15 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "c3d4e5f6a7b8"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ml_management_vectorindex", sa.Column("memory_budget", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("ml_management_vectorindex", "memory_budget")

--- a/cellarium/cas_backend/core/db/models/ml_management.py
+++ b/cellarium/cas_backend/core/db/models/ml_management.py
@@ -85,6 +85,7 @@ class CASVectorIndex(db.Base):
     distance_metric = sa.Column(sa.String(255), nullable=False)
     nprobe = sa.Column(sa.Integer, nullable=True)
     l_search = sa.Column(sa.Integer, nullable=True)
+    memory_budget = sa.Column(sa.Integer, nullable=True)
     model_id = sa.Column(sa.Integer, sa.ForeignKey(f"{CASModel.__tablename__}.id"), nullable=False, unique=True)
     model = relationship("CASModel", backref=backref("cas_vector_index", uselist=False))
 

--- a/deploy/cloudrun/default.json
+++ b/deploy/cloudrun/default.json
@@ -12,6 +12,6 @@
     "memory": "32Gi",
     "max-instances": 200,
     "min-instances": 0,
-    "concurrency": 4
+    "concurrency": 1
   }
 }

--- a/tests/unit/test_tiledb_vector_search.py
+++ b/tests/unit/test_tiledb_vector_search.py
@@ -11,8 +11,9 @@ from tests.unit.fixtures import constants
 
 
 class FakeIVFFlatIndex:
-    def __init__(self, uri):
+    def __init__(self, uri, **kwargs):
         self.uri = uri
+        self.init_kwargs = kwargs
         self.query_calls = []
 
     def get_dimensions(self):
@@ -44,6 +45,7 @@ def _build_vector_index(**overrides) -> models.CASVectorIndex:
         "distance_metric": constants.TEST_VECTOR_DISTANCE_METRIC,
         "nprobe": constants.TEST_VECTOR_INDEX_NPROBE,
         "l_search": constants.TEST_VECTOR_INDEX_L_SEARCH,
+        "memory_budget": None,
     }
     payload.update(overrides)
     return models.CASVectorIndex(**payload)
@@ -103,3 +105,25 @@ def test_match_raises_for_query_dimension_mismatch(monkeypatch: pytest.MonkeyPat
 
     with pytest.raises(VectorSearchConfigurationError, match="Embedding dimension"):
         client.match(embeddings=np.array([[1.0, 2.0, 3.0]], dtype=np.float32))
+
+
+def test_memory_budget_none_does_not_pass_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "cellarium.cas_backend.apps.compute.vector_search.tiledb.vector_search.ivf_flat_index.IVFFlatIndex",
+        FakeIVFFlatIndex,
+    )
+
+    client = TileDBVectorSearch(index=_build_vector_index(memory_budget=None))
+
+    assert "memory_budget" not in client.index_obj.init_kwargs
+
+
+def test_memory_budget_provided_passes_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "cellarium.cas_backend.apps.compute.vector_search.tiledb.vector_search.ivf_flat_index.IVFFlatIndex",
+        FakeIVFFlatIndex,
+    )
+
+    client = TileDBVectorSearch(index=_build_vector_index(memory_budget=4_000_000))
+
+    assert client.index_obj.init_kwargs["memory_budget"] == 4_000_000

--- a/tests/unit/test_vector_search_factory.py
+++ b/tests/unit/test_vector_search_factory.py
@@ -35,6 +35,7 @@ def _build_vector_index(**overrides) -> models.CASVectorIndex:
         "distance_metric": constants.TEST_VECTOR_DISTANCE_METRIC,
         "nprobe": constants.TEST_VECTOR_INDEX_NPROBE,
         "l_search": constants.TEST_VECTOR_INDEX_L_SEARCH,
+        "memory_budget": None,
     }
     payload.update(overrides)
     return models.CASVectorIndex(**payload)


### PR DESCRIPTION
3 things: 
1. This change allows CAS backend to use Models without dependence on the dataloader that was used for training the model. 
2. memory budget attribute for vs index can be changed via admin
3. deployment config is changed to be 1 instance per 1 request. Now all compute allocates to one request processing.