### PR TITLE
Index thinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,10 @@ celerybeat.pid
 # Environments
 *.env
 *.env.*
+python
+python3.10
+python3.11
+python3.12
 .venv
 .venv-linux/
 env/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 ~~~~~
 - Added ``create_vsindex`` script and CLI for building vector search indexes, moved from the external pipeline repository (#220, #221)
 - Added unit tests for the ``create_vsindex`` script
+- Added an allow-list (thinning) option to ``create_vsindex`` that filters cells by ``soma_joinid``, indexing only allowed cells while preserving the train/update split (#225)
 
 Changed
 ~~~~~~~

--- a/cellarium/cas_backend/scripts/README.rst
+++ b/cellarium/cas_backend/scripts/README.rst
@@ -140,3 +140,13 @@ Arguments
 .. option:: --update-chunk-size
 
    Number of batches per streaming-update chunk. Default: 50.
+
+.. option:: --allow-list-csv
+
+   Optional path (local or ``gs://``) to a CSV file with a single ``soma_joinid``
+   column (header included). When provided, only cells whose ID appears in the
+   allow-list are indexed; all other cells are dropped. The training set is filled to
+   ``--training-sample-size`` allowed cells and the remaining allowed cells (including
+   the leftover of the boundary batch) form the update set, so every allowed cell is
+   indexed exactly once. The script does not verify the allow-list is a genuine
+   subsample of the embeddings — that is the caller's responsibility.

--- a/cellarium/cas_backend/scripts/create_vsindex.py
+++ b/cellarium/cas_backend/scripts/create_vsindex.py
@@ -97,18 +97,24 @@ def _read_csv_gz(path: str) -> pd.DataFrame:
 
 
 @_transport_retry
-def _load_allowed_ids(path: str) -> set[int]:
+def _load_allowed_ids(path: str) -> pd.Index:
     """
-    Read the allow-list CSV (single 'soma_joinid' column, header included) into a set.
+    Read the allow-list CSV (single 'soma_joinid' column, header included) into a pd.Index.
+
+    Returns a pd.Index (int64) whose internal hash table is built once here and reused by
+    every per-batch isin() call. Passing a plain Python set to isin() forces pandas to
+    re-iterate the entire set and rebuild a temporary object array on EVERY call — for
+    millions of IDs across thousands of batches that overhead compounds to hours. A pd.Index
+    avoids that entirely: isin() routes through values._engine.ismember() which reuses the
+    pre-built C-level hash table with zero per-call setup overhead.
 
     Unlike _read_csv_gz (header-less embedding batches), this CSV has a header row so
-    pandas infers it. smart_open transparently decompresses a .gz path. The set is built
-    once here and reused for every per-batch membership check.
+    pandas infers it. smart_open transparently decompresses a .gz path.
     """
     with open(path, "rb") as f:
         buf = io.BytesIO(f.read())
     df = pd.read_csv(buf)
-    return set(df["soma_joinid"].to_numpy(dtype=np.int64).tolist())
+    return pd.Index(df["soma_joinid"].to_numpy(dtype=np.int64))
 
 
 def _normalize_in_place(arr: np.ndarray) -> None:
@@ -147,7 +153,7 @@ def _load_training_data(
     embedding_dim: int,
     training_sample_size: int,
     normalize: bool,
-    allowed_ids: set[int] | None = None,
+    allowed_ids: pd.Index | None = None,
 ) -> tuple[np.ndarray, np.ndarray, int, int, tuple[np.ndarray, np.ndarray] | None]:
     """
     Phase 1 (loading): Read batch files until training_sample_size vectors are collected.
@@ -295,7 +301,7 @@ def _process_chunk(
     embeddings_prefix: str,
     embedding_dim: int,
     normalize: bool,
-    allowed_ids: set[int] | None = None,
+    allowed_ids: pd.Index | None = None,
 ) -> int:
     """
     Read a chunk of batches and write them to the index via update_batch.
@@ -356,7 +362,7 @@ def _stream_updates(
     remaining_batches: list[int],
     normalize: bool,
     update_chunk_size: int,
-    allowed_ids: set[int] | None = None,
+    allowed_ids: pd.Index | None = None,
     carryover: tuple[np.ndarray, np.ndarray] | None = None,
 ) -> int:
     """

--- a/cellarium/cas_backend/scripts/create_vsindex.py
+++ b/cellarium/cas_backend/scripts/create_vsindex.py
@@ -3,10 +3,13 @@ Create a TileDB IVF_FLAT vector search index from .csv.gz embedding batches.
 
 Operates in three phases:
   1. Training      — read batch files until training_sample_size vectors are collected,
-                     then create the IVF_FLAT index from those vectors.
-  2. Streaming     — append all remaining batch files to the index in chunks.
+                     then create the IVF_FLAT index from those vectors. With an allow-list,
+                     only cells whose soma_joinid is in the list are kept, and the training
+                     set is filled to exactly training_sample_size allowed cells.
+  2. Streaming     — append all remaining batch files to the index in chunks, plus any allowed
+                     cells left over from the boundary batch when an allow-list is used.
   3. Consolidation — merge updates, retrain centroids, vacuum.
-                     Skipped if Phase 1 consumed all batches.
+                     Skipped if no vectors were written in the streaming phase.
 
 Example::
 
@@ -93,6 +96,21 @@ def _read_csv_gz(path: str) -> pd.DataFrame:
         return pd.read_csv(buf, header=None)
 
 
+@_transport_retry
+def _load_allowed_ids(path: str) -> set[int]:
+    """
+    Read the allow-list CSV (single 'soma_joinid' column, header included) into a set.
+
+    Unlike _read_csv_gz (header-less embedding batches), this CSV has a header row so
+    pandas infers it. smart_open transparently decompresses a .gz path. The set is built
+    once here and reused for every per-batch membership check.
+    """
+    with open(path, "rb") as f:
+        buf = io.BytesIO(f.read())
+    df = pd.read_csv(buf)
+    return set(df["soma_joinid"].to_numpy(dtype=np.int64).tolist())
+
+
 def _normalize_in_place(arr: np.ndarray) -> None:
     """L2-normalize rows of arr in-place. Clamps norms to >= 1e-12 to avoid division by zero."""
     norms = np.linalg.norm(arr, axis=1, keepdims=True)
@@ -129,40 +147,76 @@ def _load_training_data(
     embedding_dim: int,
     training_sample_size: int,
     normalize: bool,
-) -> tuple[np.ndarray, np.ndarray, int, int]:
+    allowed_ids: set[int] | None = None,
+) -> tuple[np.ndarray, np.ndarray, int, int, tuple[np.ndarray, np.ndarray] | None]:
     """
     Phase 1 (loading): Read batch files until training_sample_size vectors are collected.
 
-    Returns (ids [uint64], embeddings [float32], training_batches_used, total_training_rows).
+    When allowed_ids is supplied, each batch is filtered to allow-listed soma_joinids and the
+    training set is filled to exactly training_sample_size allowed cells; the boundary batch's
+    leftover allowed cells are returned as a carryover for the update set (never dropped).
+
+    Returns (ids [uint64], embeddings [float32], training_batches_used, total_training_rows,
+    carryover) where carryover is None or a (ids [uint64], embeddings [float32]) pair of raw
+    (un-normalized) leftover cells.
     """
     t0 = time.time()
     logging.info("Phase 1: Loading training data …")
 
-    dfs = []
+    train_dfs = []
+    carry_df = None
     total_training_rows = 0
     training_batches_used = 0
 
     for i in range(total_batches):
         df = _read_csv_gz(f"{embeddings_prefix}/batch_{i}.csv.gz")
-        dfs.append(df)
-        total_training_rows += len(df)
         training_batches_used = i + 1
-        if i % 100 == 0 and i > 0:
-            logging.info(f"  Loaded {training_batches_used} batches, {total_training_rows} vectors so far …")
-        if total_training_rows >= training_sample_size:
-            break
+        if allowed_ids is None:
+            # No thinning: whole-batch fill — original behavior, unchanged.
+            train_dfs.append(df)
+            total_training_rows += len(df)
+            if i % 100 == 0 and i > 0:
+                logging.info(f"  Loaded {training_batches_used} batches, {total_training_rows} vectors so far …")
+            if total_training_rows >= training_sample_size:
+                break
+        else:
+            # Thinning: filter by allow-list, then fill to EXACTLY training_sample_size,
+            # carrying the boundary batch's leftover allowed cells into the update set.
+            df = df[df.iloc[:, 0].isin(allowed_ids)]
+            if total_training_rows + len(df) >= training_sample_size:
+                need = training_sample_size - total_training_rows
+                train_dfs.append(df.iloc[:need])
+                carry_df = df.iloc[need:]
+                total_training_rows += need
+                break
+            train_dfs.append(df)
+            total_training_rows += len(df)
+            if i % 100 == 0 and i > 0:
+                logging.info(f"  Loaded {training_batches_used} batches, {total_training_rows} vectors so far …")
+
+    if total_training_rows == 0:
+        raise ValueError(
+            "No training vectors collected. When an allow-list is supplied, it must match at least "
+            "one cell in the input batches."
+        )
 
     ids = np.empty(total_training_rows, dtype=np.uint64)
     embeddings = np.empty((total_training_rows, embedding_dim), dtype=np.float32)
 
     offset = 0
-    for df in dfs:
+    for df in train_dfs:
         n = len(df)
         ids[offset : offset + n] = df.iloc[:, 0].to_numpy(dtype=np.uint64)
         embeddings[offset : offset + n] = df.iloc[:, 1:].to_numpy(dtype=np.float32)
         offset += n
 
-    del dfs
+    carryover = None
+    if carry_df is not None and len(carry_df):
+        carry_ids = carry_df.iloc[:, 0].to_numpy(dtype=np.uint64)
+        carry_emb = carry_df.iloc[:, 1:].to_numpy(dtype=np.float32)
+        carryover = (carry_ids, carry_emb)
+
+    del train_dfs
     gc.collect()
 
     if normalize:
@@ -172,7 +226,7 @@ def _load_training_data(
         f"Training data loaded: {total_training_rows} vectors from {training_batches_used} batches "
         f"in {time.time()-t0:.1f}s"
     )
-    return ids, embeddings, training_batches_used, total_training_rows
+    return ids, embeddings, training_batches_used, total_training_rows, carryover
 
 
 @_tiledb_retry
@@ -225,6 +279,15 @@ def _create_index(
     return index
 
 
+def _pack_and_update(index: vs.IVFFlatIndex, ids: np.ndarray, emb: np.ndarray) -> None:
+    """Pack row embeddings into a TileDB object array and write them via update_batch."""
+    n = len(ids)
+    emb_obj = np.empty(n, dtype=object)
+    for j in range(n):
+        emb_obj[j] = emb[j]
+    index.update_batch(vectors=emb_obj, external_ids=ids.astype(np.int64))
+
+
 @_tiledb_retry
 def _process_chunk(
     index: vs.IVFFlatIndex,
@@ -232,6 +295,7 @@ def _process_chunk(
     embeddings_prefix: str,
     embedding_dim: int,
     normalize: bool,
+    allowed_ids: set[int] | None = None,
 ) -> int:
     """
     Read a chunk of batches and write them to the index via update_batch.
@@ -241,7 +305,11 @@ def _process_chunk(
     supersedes the earlier write, so re-running the same chunk is idempotent.
     """
     chunk_dfs = [_read_csv_gz(f"{embeddings_prefix}/batch_{i}.csv.gz") for i in chunk_indices]
+    if allowed_ids is not None:
+        chunk_dfs = [df[df.iloc[:, 0].isin(allowed_ids)] for df in chunk_dfs]
     chunk_rows = sum(len(df) for df in chunk_dfs)
+    if chunk_rows == 0:
+        return 0
 
     chunk_ids = np.empty(chunk_rows, dtype=np.uint64)
     chunk_emb = np.empty((chunk_rows, embedding_dim), dtype=np.float32)
@@ -259,16 +327,26 @@ def _process_chunk(
     if normalize:
         _normalize_in_place(chunk_emb)
 
-    emb_obj = np.empty(chunk_rows, dtype=object)
-    for j in range(chunk_rows):
-        emb_obj[j] = chunk_emb[j]
+    _pack_and_update(index, chunk_ids, chunk_emb)
 
-    index.update_batch(vectors=emb_obj, external_ids=chunk_ids.astype(np.int64))
-
-    del chunk_ids, chunk_emb, emb_obj
+    del chunk_ids, chunk_emb
     gc.collect()
 
     return chunk_rows
+
+
+@_tiledb_retry
+def _write_carryover(index: vs.IVFFlatIndex, ids: np.ndarray, emb: np.ndarray, normalize: bool) -> int:
+    """
+    Write the boundary batch's leftover allowed cells (carried from Phase 1) to the update set.
+
+    Retry-safe for the same reason as _process_chunk (update_batch is idempotent under a later
+    timestamp). Returns rows written.
+    """
+    if normalize:
+        _normalize_in_place(emb)
+    _pack_and_update(index, ids, emb)
+    return len(ids)
 
 
 def _stream_updates(
@@ -278,23 +356,35 @@ def _stream_updates(
     remaining_batches: list[int],
     normalize: bool,
     update_chunk_size: int,
+    allowed_ids: set[int] | None = None,
+    carryover: tuple[np.ndarray, np.ndarray] | None = None,
 ) -> int:
     """
     Phase 2: Stream remaining batches into the index in chunks.
 
-    Returns total_vectors_written (0 if remaining_batches is empty, no index mutation).
+    Writes any boundary-batch carryover first (leftover allowed cells from Phase 1), then the
+    remaining batches (each filtered by allowed_ids when thinning). Returns the total number of
+    vectors written across carryover and chunks.
     """
+    total_updated = 0
+
+    if carryover is not None:
+        c_ids, c_emb = carryover
+        if len(c_ids):
+            logging.info(f"Phase 2: writing {len(c_ids)} carried-over boundary-batch cells …")
+            total_updated += _write_carryover(index, c_ids, c_emb, normalize)
+
     if not remaining_batches:
-        logging.info("Phase 2: No remaining batches; skipping.")
-        return 0
+        if total_updated == 0:
+            logging.info("Phase 2: No remaining batches; skipping.")
+        return total_updated
 
     t0 = time.time()
     logging.info(f"Phase 2: Streaming {len(remaining_batches)} update batches …")
-    total_updated = 0
 
     for chunk_num, chunk_start in enumerate(range(0, len(remaining_batches), update_chunk_size)):
         chunk_indices = remaining_batches[chunk_start : chunk_start + update_chunk_size]
-        total_updated += _process_chunk(index, chunk_indices, embeddings_prefix, embedding_dim, normalize)
+        total_updated += _process_chunk(index, chunk_indices, embeddings_prefix, embedding_dim, normalize, allowed_ids)
         if chunk_num % 5 == 4:
             batches_done = chunk_start + len(chunk_indices)
             logging.info(
@@ -345,10 +435,15 @@ def create_vsindex(
     normalize: bool = True,
     max_partitions: int = 65536,
     update_chunk_size: int = 50,
+    allow_list_csv: str | None = None,
 ) -> None:
     """
     Create a TileDB IVF_FLAT vector search index from .csv.gz embedding batches.
     Callable directly from pipeline code without going through the CLI.
+
+    When allow_list_csv is given, only cells whose soma_joinid appears in that CSV are indexed;
+    the training set is filled to exactly training_sample_size allowed cells and every remaining
+    allowed cell (including the boundary batch's leftover) is streamed into the update set.
     """
     t0 = time.time()
     logging.info(
@@ -356,8 +451,12 @@ def create_vsindex(
         f"metric={distance_metric}, normalize={normalize}"
     )
 
-    ids, embeddings, training_batches_used, total_training_rows = _load_training_data(
-        embeddings_prefix, total_batches, embedding_dim, training_sample_size, normalize
+    allowed_ids = _load_allowed_ids(allow_list_csv) if allow_list_csv else None
+    if allowed_ids is not None:
+        logging.info(f"Thinning enabled: {len(allowed_ids)} allowed cell IDs from {allow_list_csv}")
+
+    ids, embeddings, training_batches_used, total_training_rows, carryover = _load_training_data(
+        embeddings_prefix, total_batches, embedding_dim, training_sample_size, normalize, allowed_ids
     )
     index = _create_index(
         ids,
@@ -374,9 +473,18 @@ def create_vsindex(
     gc.collect()
 
     remaining_batches = list(range(training_batches_used, total_batches))
-    _stream_updates(index, embeddings_prefix, embedding_dim, remaining_batches, normalize, update_chunk_size)
+    total_updated = _stream_updates(
+        index,
+        embeddings_prefix,
+        embedding_dim,
+        remaining_batches,
+        normalize,
+        update_chunk_size,
+        allowed_ids,
+        carryover,
+    )
 
-    if remaining_batches:
+    if total_updated > 0:
         index = _consolidate(index, index_path, normalize)
 
     logging.info(f"vsindex creation complete in {time.time()-t0:.1f}s — final size: {index.size}")

--- a/cellarium/cas_backend/scripts/create_vsindex.py
+++ b/cellarium/cas_backend/scripts/create_vsindex.py
@@ -2,12 +2,12 @@
 Create a TileDB IVF_FLAT vector search index from .csv.gz embedding batches.
 
 Operates in three phases:
-  1. Training      — read batch files until training_sample_size vectors are collected,
-                     then create the IVF_FLAT index from those vectors. With an allow-list,
-                     only cells whose soma_joinid is in the list are kept, and the training
-                     set is filled to exactly training_sample_size allowed cells.
-  2. Streaming     — append all remaining batch files to the index in chunks, plus any allowed
-                     cells left over from the boundary batch when an allow-list is used.
+  1. Training      — read batch files until at least training_sample_size vectors are collected,
+                     then create the IVF_FLAT index from those vectors. With an allow-list, each
+                     batch is filtered before appending; the boundary batch may overshoot
+                     training_sample_size slightly (same behaviour as the no-filter path).
+  2. Streaming     — append all remaining batch files to the index in chunks, filtered by the
+                     allow-list when thinning is enabled.
   3. Consolidation — merge updates, retrain centroids, vacuum.
                      Skipped if no vectors were written in the streaming phase.
 
@@ -154,51 +154,33 @@ def _load_training_data(
     training_sample_size: int,
     normalize: bool,
     allowed_ids: pd.Index | None = None,
-) -> tuple[np.ndarray, np.ndarray, int, int, tuple[np.ndarray, np.ndarray] | None]:
+) -> tuple[np.ndarray, np.ndarray, int, int]:
     """
-    Phase 1 (loading): Read batch files until training_sample_size vectors are collected.
+    Phase 1 (loading): Read batch files until at least training_sample_size vectors are collected.
 
-    When allowed_ids is supplied, each batch is filtered to allow-listed soma_joinids and the
-    training set is filled to exactly training_sample_size allowed cells; the boundary batch's
-    leftover allowed cells are returned as a carryover for the update set (never dropped).
+    When allowed_ids is supplied, each batch is filtered before appending; the boundary batch
+    is appended whole (may slightly overshoot training_sample_size), matching the no-filter path.
 
-    Returns (ids [uint64], embeddings [float32], training_batches_used, total_training_rows,
-    carryover) where carryover is None or a (ids [uint64], embeddings [float32]) pair of raw
-    (un-normalized) leftover cells.
+    Returns (ids [uint64], embeddings [float32], training_batches_used, total_training_rows).
     """
     t0 = time.time()
     logging.info("Phase 1: Loading training data …")
 
     train_dfs = []
-    carry_df = None
     total_training_rows = 0
     training_batches_used = 0
 
     for i in range(total_batches):
         df = _read_csv_gz(f"{embeddings_prefix}/batch_{i}.csv.gz")
         training_batches_used = i + 1
-        if allowed_ids is None:
-            # No thinning: whole-batch fill — original behavior, unchanged.
-            train_dfs.append(df)
-            total_training_rows += len(df)
-            if i % 100 == 0 and i > 0:
-                logging.info(f"  Loaded {training_batches_used} batches, {total_training_rows} vectors so far …")
-            if total_training_rows >= training_sample_size:
-                break
-        else:
-            # Thinning: filter by allow-list, then fill to EXACTLY training_sample_size,
-            # carrying the boundary batch's leftover allowed cells into the update set.
+        if allowed_ids is not None:
             df = df[df.iloc[:, 0].isin(allowed_ids)]
-            if total_training_rows + len(df) >= training_sample_size:
-                need = training_sample_size - total_training_rows
-                train_dfs.append(df.iloc[:need])
-                carry_df = df.iloc[need:]
-                total_training_rows += need
-                break
-            train_dfs.append(df)
-            total_training_rows += len(df)
-            if i % 100 == 0 and i > 0:
-                logging.info(f"  Loaded {training_batches_used} batches, {total_training_rows} vectors so far …")
+        train_dfs.append(df)
+        total_training_rows += len(df)
+        if i % 100 == 0 and i > 0:
+            logging.info(f"  Loaded {training_batches_used} batches, {total_training_rows} vectors so far …")
+        if total_training_rows >= training_sample_size:
+            break
 
     if total_training_rows == 0:
         raise ValueError(
@@ -216,12 +198,6 @@ def _load_training_data(
         embeddings[offset : offset + n] = df.iloc[:, 1:].to_numpy(dtype=np.float32)
         offset += n
 
-    carryover = None
-    if carry_df is not None and len(carry_df):
-        carry_ids = carry_df.iloc[:, 0].to_numpy(dtype=np.uint64)
-        carry_emb = carry_df.iloc[:, 1:].to_numpy(dtype=np.float32)
-        carryover = (carry_ids, carry_emb)
-
     del train_dfs
     gc.collect()
 
@@ -232,7 +208,7 @@ def _load_training_data(
         f"Training data loaded: {total_training_rows} vectors from {training_batches_used} batches "
         f"in {time.time()-t0:.1f}s"
     )
-    return ids, embeddings, training_batches_used, total_training_rows, carryover
+    return ids, embeddings, training_batches_used, total_training_rows
 
 
 @_tiledb_retry
@@ -341,20 +317,6 @@ def _process_chunk(
     return chunk_rows
 
 
-@_tiledb_retry
-def _write_carryover(index: vs.IVFFlatIndex, ids: np.ndarray, emb: np.ndarray, normalize: bool) -> int:
-    """
-    Write the boundary batch's leftover allowed cells (carried from Phase 1) to the update set.
-
-    Retry-safe for the same reason as _process_chunk (update_batch is idempotent under a later
-    timestamp). Returns rows written.
-    """
-    if normalize:
-        _normalize_in_place(emb)
-    _pack_and_update(index, ids, emb)
-    return len(ids)
-
-
 def _stream_updates(
     index: vs.IVFFlatIndex,
     embeddings_prefix: str,
@@ -363,28 +325,16 @@ def _stream_updates(
     normalize: bool,
     update_chunk_size: int,
     allowed_ids: pd.Index | None = None,
-    carryover: tuple[np.ndarray, np.ndarray] | None = None,
 ) -> int:
     """
-    Phase 2: Stream remaining batches into the index in chunks.
-
-    Writes any boundary-batch carryover first (leftover allowed cells from Phase 1), then the
-    remaining batches (each filtered by allowed_ids when thinning). Returns the total number of
-    vectors written across carryover and chunks.
+    Phase 2: Stream remaining batches into the index in chunks, filtered by allowed_ids when
+    thinning. Returns the total number of vectors written.
     """
-    total_updated = 0
-
-    if carryover is not None:
-        c_ids, c_emb = carryover
-        if len(c_ids):
-            logging.info(f"Phase 2: writing {len(c_ids)} carried-over boundary-batch cells …")
-            total_updated += _write_carryover(index, c_ids, c_emb, normalize)
-
     if not remaining_batches:
-        if total_updated == 0:
-            logging.info("Phase 2: No remaining batches; skipping.")
-        return total_updated
+        logging.info("Phase 2: No remaining batches; skipping.")
+        return 0
 
+    total_updated = 0
     t0 = time.time()
     logging.info(f"Phase 2: Streaming {len(remaining_batches)} update batches …")
 
@@ -447,9 +397,7 @@ def create_vsindex(
     Create a TileDB IVF_FLAT vector search index from .csv.gz embedding batches.
     Callable directly from pipeline code without going through the CLI.
 
-    When allow_list_csv is given, only cells whose soma_joinid appears in that CSV are indexed;
-    the training set is filled to exactly training_sample_size allowed cells and every remaining
-    allowed cell (including the boundary batch's leftover) is streamed into the update set.
+    When allow_list_csv is given, only cells whose soma_joinid appears in that CSV are indexed.
     """
     t0 = time.time()
     logging.info(
@@ -461,7 +409,7 @@ def create_vsindex(
     if allowed_ids is not None:
         logging.info(f"Thinning enabled: {len(allowed_ids)} allowed cell IDs from {allow_list_csv}")
 
-    ids, embeddings, training_batches_used, total_training_rows, carryover = _load_training_data(
+    ids, embeddings, training_batches_used, total_training_rows = _load_training_data(
         embeddings_prefix, total_batches, embedding_dim, training_sample_size, normalize, allowed_ids
     )
     index = _create_index(
@@ -487,7 +435,6 @@ def create_vsindex(
         normalize,
         update_chunk_size,
         allowed_ids,
-        carryover,
     )
 
     if total_updated > 0:

--- a/cellarium/cas_backend/scripts/create_vsindex_cli.py
+++ b/cellarium/cas_backend/scripts/create_vsindex_cli.py
@@ -44,6 +44,16 @@ from cellarium.cas_backend.scripts.create_vsindex import create_vsindex
 @click.option(
     "--update-chunk-size", default=50, show_default=True, type=int, help="Number of batches per streaming-update chunk."
 )
+@click.option(
+    "--allow-list-csv",
+    default=None,
+    type=str,
+    help=(
+        "Optional path (local or gs://) to a CSV with a single 'soma_joinid' column (header "
+        "included). When provided, only cells whose ID appears in the allow-list are indexed; "
+        "all others are dropped."
+    ),
+)
 def main(
     embeddings_prefix: str,
     index_path: str,
@@ -54,6 +64,7 @@ def main(
     normalize: bool,
     max_partitions: int,
     update_chunk_size: int,
+    allow_list_csv: str | None,
 ) -> None:
     """Create a TileDB IVF_FLAT vector search index from .csv.gz embedding batches."""
     create_vsindex(
@@ -66,6 +77,7 @@ def main(
         normalize=normalize,
         max_partitions=max_partitions,
         update_chunk_size=update_chunk_size,
+        allow_list_csv=allow_list_csv,
     )
 
 

--- a/tests/unit/scripts/conftest.py
+++ b/tests/unit/scripts/conftest.py
@@ -1,0 +1,35 @@
+"""
+Test-harness conftest for scripts unit tests.
+
+On platforms where tiledb-vector-search is unavailable (e.g. linux/aarch64), inject
+minimal sys.modules stubs so create_vsindex can be imported without the native wheel.
+This is a test-only shim; it does not affect the production module's import statement.
+
+Specifically, thanks to `from __future__ import annotations`, all `vs.IVFFlatIndex`
+annotations in create_vsindex.py are lazy strings and are never evaluated at import
+time.  The only runtime tiledb reference during import is `tiledb.TileDBError` used by
+the `_tiledb_retry` decorator — the stub below satisfies exactly that.
+"""
+
+import sys
+import types
+
+
+def _install_tiledb_stub() -> None:
+    """Insert minimal tiledb stub when the real package is absent."""
+    real = sys.modules.get("tiledb")
+    if real is not None and hasattr(real, "TileDBError"):
+        return  # real tiledb already present; nothing to do
+
+    tdb = types.ModuleType("tiledb")
+    tdb.TileDBError = type("TileDBError", (Exception,), {})  # type: ignore[attr-defined]
+    tdb.VFS = None  # will be replaced by monkeypatch in individual tests  # type: ignore[attr-defined]
+
+    vsmod = types.ModuleType("tiledb.vector_search")
+    tdb.vector_search = vsmod  # type: ignore[attr-defined]
+
+    sys.modules.setdefault("tiledb", tdb)
+    sys.modules.setdefault("tiledb.vector_search", vsmod)
+
+
+_install_tiledb_stub()

--- a/tests/unit/scripts/test_create_vsindex.py
+++ b/tests/unit/scripts/test_create_vsindex.py
@@ -11,6 +11,7 @@ import io
 
 from click.testing import CliRunner
 import numpy as np
+import pandas as pd
 import pytest
 import tenacity
 import tiledb
@@ -18,9 +19,12 @@ import tiledb
 from cellarium.cas_backend.scripts.create_vsindex import (
     _choose_partitions,
     _create_index,
+    _load_allowed_ids,
+    _load_training_data,
     _normalize_in_place,
     _process_chunk,
     _read_csv_gz,
+    create_vsindex,
 )
 from cellarium.cas_backend.scripts.create_vsindex_cli import main
 
@@ -47,6 +51,13 @@ def _make_open_stub(raw: bytes):
         return _FakeCtxMgr(raw)
 
     return _open
+
+
+def _fake_batch_read(path):
+    """Fake _read_csv_gz: batch i → 3 rows, ids [3i, 3i+1, 3i+2], two embedding columns."""
+    i = int(path.split("batch_")[1].split(".")[0])
+    b = i * 3
+    return pd.DataFrame({0: [b, b + 1, b + 2], 1: [0.1, 0.2, 0.3], 2: [0.4, 0.5, 0.6]})
 
 
 class _FakeIndex:
@@ -346,4 +357,139 @@ def test_main_calls_create_vsindex_with_correct_kwargs(monkeypatch, tmp_path):
         "normalize": False,
         "max_partitions": 8192,
         "update_chunk_size": 50,
+        "allow_list_csv": None,
     }
+
+
+# Thinning / allow-list
+
+
+def test_main_passes_allow_list_csv(monkeypatch, tmp_path):
+    """CLI forwards --allow-list-csv to create_vsindex as the allow_list_csv kwarg."""
+    import cellarium.cas_backend.scripts.create_vsindex_cli as cli_mod
+
+    captured = _FakeCreateVsindex()
+    monkeypatch.setattr(cli_mod, "create_vsindex", captured)
+    allow = str(tmp_path / "allow.csv")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "--embeddings-prefix",
+            str(tmp_path / "emb"),
+            "--index-path",
+            str(tmp_path / "idx"),
+            "--total-batches",
+            "10",
+            "--embedding-dim",
+            "64",
+            "--allow-list-csv",
+            allow,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured.called_kwargs["allow_list_csv"] == allow
+
+
+def test_load_allowed_ids_reads_soma_joinid_column(monkeypatch):
+    """_load_allowed_ids parses the 'soma_joinid' header column into a set of ints."""
+    import cellarium.cas_backend.scripts.create_vsindex as mod
+
+    monkeypatch.setattr(mod, "open", _make_open_stub(b"soma_joinid\n0\n2\n5\n"))
+    assert _load_allowed_ids("/fake") == {0, 2, 5}
+
+
+def test_load_training_data_thinning_caps_and_carries_over(monkeypatch):
+    """Thinning fills training to exactly training_sample_size and carries the boundary leftover."""
+    import cellarium.cas_backend.scripts.create_vsindex as mod
+
+    monkeypatch.setattr(mod, "_read_csv_gz", _fake_batch_read)
+
+    ids, _embeddings, training_batches_used, total_training_rows, carryover = _load_training_data(
+        "/p",
+        total_batches=3,
+        embedding_dim=2,
+        training_sample_size=3,
+        normalize=False,
+        allowed_ids={0, 2, 3, 5, 6, 8},
+    )
+
+    assert ids.tolist() == [0, 2, 3]
+    assert training_batches_used == 2
+    assert total_training_rows == 3
+    assert carryover is not None
+    assert carryover[0].tolist() == [5]
+
+
+def test_load_training_data_empty_allow_list_raises(monkeypatch):
+    """An allow-list matching no input cell yields zero training rows and raises ValueError."""
+    import cellarium.cas_backend.scripts.create_vsindex as mod
+
+    monkeypatch.setattr(mod, "_read_csv_gz", _fake_batch_read)
+
+    with pytest.raises(ValueError):
+        _load_training_data(
+            "/p",
+            total_batches=3,
+            embedding_dim=2,
+            training_sample_size=3,
+            normalize=False,
+            allowed_ids={999},
+        )
+
+
+def test_create_vsindex_thinning_no_allowed_cell_lost(monkeypatch):
+    """End-to-end (stubbed): each allow-listed cell lands in exactly one of train/update; none lost."""
+    import cellarium.cas_backend.scripts.create_vsindex as mod
+
+    class _CapIndex:
+        def __init__(self):
+            self.update_ids = []
+            self.size = 0
+
+        def update_batch(self, **kw):
+            self.update_ids.append(np.asarray(kw["external_ids"]))
+
+        def consolidate_updates(self, **kw):
+            pass
+
+        def vacuum(self):
+            pass
+
+    fake_index = _CapIndex()
+
+    class _CapIngest:
+        def __init__(self):
+            self.external_ids = None
+
+        def __call__(self, **kw):
+            self.external_ids = np.asarray(kw["external_ids"])
+            return fake_index
+
+    fake_ingest = _CapIngest()
+
+    monkeypatch.setattr(mod, "_read_csv_gz", _fake_batch_read)
+    monkeypatch.setattr(mod, "_load_allowed_ids", lambda path: {0, 2, 3, 5, 6, 8})
+    monkeypatch.setattr(mod, "_resolve_distance_metric", lambda _: object())
+    monkeypatch.setattr(mod.tiledb, "VFS", lambda: _FakeVFS(exists=False))
+    monkeypatch.setattr(mod.vs, "ingest", fake_ingest, raising=False)
+    monkeypatch.setattr(mod.vs, "IVFFlatIndex", lambda _path: fake_index, raising=False)
+
+    create_vsindex(
+        "/p",
+        "/idx",
+        total_batches=3,
+        embedding_dim=2,
+        training_sample_size=3,
+        normalize=False,
+        allow_list_csv="/fake",
+    )
+
+    train = [int(x) for x in fake_ingest.external_ids.tolist()]
+    updates = [int(x) for arr in fake_index.update_ids for x in arr.tolist()]
+
+    assert set(train) | set(updates) == {0, 2, 3, 5, 6, 8}
+    assert len(train) + len(updates) == 6
+    assert 5 in set(updates)
+    assert set(train) & set(updates) == set()

--- a/tests/unit/scripts/test_create_vsindex.py
+++ b/tests/unit/scripts/test_create_vsindex.py
@@ -393,11 +393,13 @@ def test_main_passes_allow_list_csv(monkeypatch, tmp_path):
 
 
 def test_load_allowed_ids_reads_soma_joinid_column(monkeypatch):
-    """_load_allowed_ids parses the 'soma_joinid' header column into a set of ints."""
+    """_load_allowed_ids parses the 'soma_joinid' header column into a pd.Index of int64."""
     import cellarium.cas_backend.scripts.create_vsindex as mod
 
     monkeypatch.setattr(mod, "open", _make_open_stub(b"soma_joinid\n0\n2\n5\n"))
-    assert _load_allowed_ids("/fake") == {0, 2, 5}
+    result = _load_allowed_ids("/fake")
+    assert isinstance(result, pd.Index)
+    assert set(result.tolist()) == {0, 2, 5}
 
 
 def test_load_training_data_thinning_caps_and_carries_over(monkeypatch):
@@ -412,7 +414,7 @@ def test_load_training_data_thinning_caps_and_carries_over(monkeypatch):
         embedding_dim=2,
         training_sample_size=3,
         normalize=False,
-        allowed_ids={0, 2, 3, 5, 6, 8},
+        allowed_ids=pd.Index([0, 2, 3, 5, 6, 8]),
     )
 
     assert ids.tolist() == [0, 2, 3]
@@ -435,7 +437,7 @@ def test_load_training_data_empty_allow_list_raises(monkeypatch):
             embedding_dim=2,
             training_sample_size=3,
             normalize=False,
-            allowed_ids={999},
+            allowed_ids=pd.Index([999]),
         )
 
 
@@ -470,7 +472,7 @@ def test_create_vsindex_thinning_no_allowed_cell_lost(monkeypatch):
     fake_ingest = _CapIngest()
 
     monkeypatch.setattr(mod, "_read_csv_gz", _fake_batch_read)
-    monkeypatch.setattr(mod, "_load_allowed_ids", lambda path: {0, 2, 3, 5, 6, 8})
+    monkeypatch.setattr(mod, "_load_allowed_ids", lambda path: pd.Index([0, 2, 3, 5, 6, 8]))
     monkeypatch.setattr(mod, "_resolve_distance_metric", lambda _: object())
     monkeypatch.setattr(mod.tiledb, "VFS", lambda: _FakeVFS(exists=False))
     monkeypatch.setattr(mod.vs, "ingest", fake_ingest, raising=False)

--- a/tests/unit/scripts/test_create_vsindex.py
+++ b/tests/unit/scripts/test_create_vsindex.py
@@ -402,13 +402,14 @@ def test_load_allowed_ids_reads_soma_joinid_column(monkeypatch):
     assert set(result.tolist()) == {0, 2, 5}
 
 
-def test_load_training_data_thinning_caps_and_carries_over(monkeypatch):
-    """Thinning fills training to exactly training_sample_size and carries the boundary leftover."""
+def test_load_training_data_thinning_overshoots_boundary(monkeypatch):
+    """With an allow-list, the boundary batch is appended whole so training may slightly exceed
+    training_sample_size — no carryover, no mid-batch split."""
     import cellarium.cas_backend.scripts.create_vsindex as mod
 
     monkeypatch.setattr(mod, "_read_csv_gz", _fake_batch_read)
 
-    ids, _embeddings, training_batches_used, total_training_rows, carryover = _load_training_data(
+    ids, _embeddings, training_batches_used, total_training_rows = _load_training_data(
         "/p",
         total_batches=3,
         embedding_dim=2,
@@ -417,11 +418,11 @@ def test_load_training_data_thinning_caps_and_carries_over(monkeypatch):
         allowed_ids=pd.Index([0, 2, 3, 5, 6, 8]),
     )
 
-    assert ids.tolist() == [0, 2, 3]
+    # Batch 0 filtered → [0,2] (total=2 < 3, continue).
+    # Batch 1 filtered → [3,5] (total=4 ≥ 3 → append whole and break).
+    assert set(ids.tolist()) == {0, 2, 3, 5}
     assert training_batches_used == 2
-    assert total_training_rows == 3
-    assert carryover is not None
-    assert carryover[0].tolist() == [5]
+    assert total_training_rows == 4
 
 
 def test_load_training_data_empty_allow_list_raises(monkeypatch):
@@ -429,15 +430,11 @@ def test_load_training_data_empty_allow_list_raises(monkeypatch):
     import cellarium.cas_backend.scripts.create_vsindex as mod
 
     monkeypatch.setattr(mod, "_read_csv_gz", _fake_batch_read)
+    allowed_ids = pd.Index([999])
 
     with pytest.raises(ValueError):
         _load_training_data(
-            "/p",
-            total_batches=3,
-            embedding_dim=2,
-            training_sample_size=3,
-            normalize=False,
-            allowed_ids=pd.Index([999]),
+            "/p", total_batches=3, embedding_dim=2, training_sample_size=3, normalize=False, allowed_ids=allowed_ids
         )
 
 
@@ -454,9 +451,11 @@ def test_create_vsindex_thinning_no_allowed_cell_lost(monkeypatch):
             self.update_ids.append(np.asarray(kw["external_ids"]))
 
         def consolidate_updates(self, **kw):
+            # Intentional no-op stub: this test only verifies update_batch routing, not consolidation.
             pass
 
         def vacuum(self):
+            # Intentional no-op stub: vacuum behaviour is not under test here.
             pass
 
     fake_index = _CapIndex()
@@ -493,5 +492,4 @@ def test_create_vsindex_thinning_no_allowed_cell_lost(monkeypatch):
 
     assert set(train) | set(updates) == {0, 2, 3, 5, 6, 8}
     assert len(train) + len(updates) == 6
-    assert 5 in set(updates)
     assert set(train) & set(updates) == set()


### PR DESCRIPTION
Add allow-list (thinning) support to create_vsindex                                                                                                          
                                                                                                                                                                             
 Lets you build a TileDB IVF_FLAT index over a subsample of an existing embedding set without regenerating embeddings. Previously create_vsindex indexed every cell in every 
 batch file; now an optional --allow-list-csv / allow_list_csv= (local path or gs://, single soma_joinid column with header) restricts indexing to the listed cells and      
 drops the rest.                                                                                                                                                             
                                                                                                                                                                             
 Behavior                                                                                                                                                                    
 - The filter is applied per batch in both phases — training (Phase 1) and streaming updates (Phase 2) — so the train/update split is preserved and every allow-listed cell  
 is indexed exactly once. Training fills to --training-sample-size allowed cells; the boundary batch is appended whole and may slightly overshoot, matching the existing     
 unfiltered path.                                                                                                                                                            
 - Phase 3 consolidation is now gated on vectors actually written rather than "remaining batches existed" — with thinning, remaining batches can filter down to zero rows.   
 Empty chunks short-circuit instead of issuing zero-row update_batch calls.                                                                                                  
 - An allow-list matching no input cell now fails fast with a ValueError instead of erroring deep inside index creation.                                                     
 - The allow-list is held as a pd.Index, not a Python set: isin() then reuses one pre-built C-level hash table instead of rebuilding a temporary object array on every       
 per-batch call — material at millions of IDs across thousands of batches.                                                                                                   
 - The script does not verify the allow-list is a genuine subsample of the embeddings; that stays the caller's responsibility.                                               
                                                                                                                                                                             
 Also in here                                                                                                                                                                
 - Extracted _pack_and_update() to de-duplicate the object-array packing + update_batch write.                                                                               
 - Tests for CLI kwarg forwarding, _load_allowed_ids parsing, boundary overshoot, the empty-allow-list error, and a stubbed end-to-end check that the train and update ID    
 sets are disjoint and together cover exactly the allow-list.                                                                                                                
 - tests/unit/scripts/conftest.py: test-only tiledb / tiledb.vector_search stub so the module imports where the native tiledb-vector-search wheel is unavailable (e.g.       
 linux/aarch64).                                                                                                                                                             
 - .gitignore entries for stray python / python3.1x artifacts; CHANGELOG entry under 1.8.5.     

Closes #225 